### PR TITLE
Fixes #16384: stats: capture '.' in grpc_bridge_service stats tag

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -82,11 +82,15 @@ extlinks = {
 
 # Setup global substitutions
 if 'pre-release' in release_level:
-    substitutions = [('|envoy_docker_image|', 'envoy-dev:{}'.format(blob_sha)),
-                     ('|envoy_windows_docker_image|', 'envoy-windows-dev:{}'.format(blob_sha))]
+    substitutions = [
+        ('|envoy_docker_image|', 'envoy-dev:{}'.format(blob_sha)),
+        ('|envoy_windows_docker_image|', 'envoy-windows-dev:{}'.format(blob_sha)),
+        ('|envoy_distroless_docker_image|', 'envoy-distroless-dev:{}'.format(blob_sha))
+    ]
 else:
     substitutions = [('|envoy_docker_image|', 'envoy:{}'.format(blob_sha)),
-                     ('|envoy_windows_docker_image|', 'envoy-windows:{}'.format(blob_sha))]
+                     ('|envoy_windows_docker_image|', 'envoy-windows:{}'.format(blob_sha)),
+                     ('|envoy_distroless_docker_image|', 'envoy-distroless:{}'.format(blob_sha))]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/root/start/install.rst
+++ b/docs/root/start/install.rst
@@ -159,6 +159,13 @@ The following commands will pull and show the Envoy version of current images.
          $ docker pull envoyproxy/|envoy_docker_image|
          $ docker run --rm envoyproxy/|envoy_docker_image| --version
 
+   .. tab:: Envoy (distroless)
+
+      .. substitution-code-block:: console
+
+         $ docker pull envoyproxy/|envoy_distroless_docker_image|
+         $ docker run --rm envoyproxy/|envoy_distroless_docker_image| --version
+
    .. tab:: Get Envoy
 
       .. code-block:: console
@@ -201,6 +208,12 @@ The following table shows the available Docker images
      - |DOCKER_IMAGE_TAG_NAME|
      -
      -
+   * - `envoyproxy/envoy-distroless <https://hub.docker.com/r/envoyproxy/envoy-distroless/tags/>`_
+     - Release binary with symbols stripped on top of a distroless base.
+     - |DOCKER_IMAGE_TAG_NAME|
+     -
+     -
+     -
    * - `envoyproxy/envoy-alpine <https://hub.docker.com/r/envoyproxy/envoy-alpine/tags/>`_
      - Release binary with symbols stripped on top of a **glibc** alpine base.
      - |DOCKER_IMAGE_TAG_NAME|
@@ -225,6 +238,12 @@ The following table shows the available Docker images
      -
      - latest
      - latest
+   * - `envoyproxy/envoy-distroless-dev <https://hub.docker.com/r/envoyproxy/envoy-distroless-dev/tags/>`_
+     - Release binary with symbols stripped on top of a distroless base.
+     -
+     -
+     - latest
+     -
    * - `envoyproxy/envoy-alpine-dev <https://hub.docker.com/r/envoyproxy/envoy-alpine-dev/tags/>`_
      - Release binary with symbols stripped on top of a **glibc** alpine base.
      -


### PR DESCRIPTION
Commit Message: Captures '.' characters in gRPC service names in the grpc_bridge_service tag, fixing bug where '.' characters were not captured (notably present when package is included in gRPC service name).
Additional Description:
Risk Level: Low
Testing: Update existing unit tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
Fixes #16384
